### PR TITLE
Fixed issue where the leading slash was wrong on windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+.idea

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ let slice = start => thing => thing.slice(start)
 
 // Path Utils
 let sanitizeFileName = file => file.replace(/-|\.|\//g, '_')
-let stripLeadingSlash = file => file.replace(/^\//g, '')
+let stripLeadingSlash = file => file.replace(new RegExp(`^\\${path.sep}`, 'g'), '')
 let filename = file => noExt(_.last(file.split('/')))
 let relativeFilenames = (dir, exclusions) => readDir(dir, exclusions).map(slice(dir.length))
 let noExt = file => file.slice(0, _.lastIndexOf('.', file))


### PR DESCRIPTION
Hello,

When I was running this tool on my windows box I noticed that the leading slashes were still left in. Instead of using `/` I made it use `path.sep` instead.

Thanks for making this tool!